### PR TITLE
Support Satyrographos

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -28,27 +28,50 @@
 
 ## インストール方法
 
-`matrix.satyh` を `LIBROOT/dist/packages/` 下へコピーしてください (LIBROOT は環境によって変わります)。
+### Satyrographos を使用する場合
 
-### 例: Unix 系 OS
+まず、 [Satyrographos] をインストールしてください。その後、 `satysfi-matrix` パッケージをインストールし、 `satyrographos install` を実行してください。
 
 ```sh
-git clone https://github.com/nekketsuuu/satysfi-matrix.git
-cd satysfi-matrix
-cp matrix.satyh ~/.satysfi/dist/packages/
+opam install satysfi-matrix
+satyrographos install
 ```
 
-### 例: Windows
+### 手動でコピーする場合
+
+`matrix.satyh` を `LIBROOT/dist/packages/matrix/` 下へコピーしてください (LIBROOT は環境によって変わります)。
+
+#### 例: Unix 系 OS
 
 ```sh
 git clone https://github.com/nekketsuuu/satysfi-matrix.git
 cd satysfi-matrix
-copy matrix.satyh %USERPROFILE%\.satysfi\dist\packages\
+mkdir -p ~/.satysfi/dist/packages/matrix
+cp matrix.satyh ~/.satysfi/dist/packages/matrix/
+```
+
+#### 例: Windows
+
+```sh
+git clone https://github.com/nekketsuuu/satysfi-matrix.git
+cd satysfi-matrix
+mkdir %USERPROFILE%\.satysfi\dist\packages\matrix
+copy matrix.satyh %USERPROFILE%\.satysfi\dist\packages\matrix\
 ```
 
 ## アンインストール方法
 
-`LIBROOT/dist/packages/matrix.satyh` を削除してください。
+### Satyrographos を使用する場合
+
+`satysfi-matrix` パッケージをアンインストールしてください。
+
+```sh
+opam uninstall satysfi-matrix
+```
+
+### 手動でコピーする場合
+
+`LIBROOT/dist/packages/matrix/matrix.satyh` を削除してください。
 
 ## 既知の問題
 
@@ -65,3 +88,4 @@ Pull request も issue 報告も歓迎しています！　英語でも日本語
   [sample_matrix.png]: https://raw.githubusercontent.com/nekketsuuu/satysfi-matrix/master/doc/img/sample_matrix.png
   [example]: https://github.com/nekketsuuu/satysfi-matrix/blob/master/example
   [GitHub Issues]: https://github.com/nekketsuuu/satysfi-matrix/issues
+  [Satyrographos]: https://github.com/na4zagin3/satyrographos

--- a/README.md
+++ b/README.md
@@ -28,27 +28,50 @@ See [`example`][example] for more complicated examples.
 
 ## Installation
 
-Just copy `matrix.satyh` under your `LIBROOT/dist/packages/` (LIBROOT changes depending on your environment).
+### With Satyrographos
 
-### Example: Unix-like OSs
+Install [Satyrographos](https://github.com/na4zagin3/satyrographos). Then, install `satysfi-matrix` package and run `satyrographos install` as follows.
 
 ```sh
-git clone https://github.com/nekketsuuu/satysfi-matrix.git
-cd satysfi-matrix
-cp matrix.satyh ~/.satysfi/dist/packages/
+opam install satysfi-matrix
+satyrographos install
 ```
 
-### Example: Windows
+### Manually Copying
+
+Just copy `matrix.satyh` under your `LIBROOT/dist/packages/matrix/` (LIBROOT changes depending on your environment).
+
+#### Example: Unix-like OSs
 
 ```sh
 git clone https://github.com/nekketsuuu/satysfi-matrix.git
 cd satysfi-matrix
-copy matrix.satyh %USERPROFILE%\.satysfi\dist\packages\
+mkdir -p ~/.satysfi/dist/packages/matrix
+cp matrix.satyh ~/.satysfi/dist/packages/matrix/
+```
+
+#### Example: Windows
+
+```sh
+git clone https://github.com/nekketsuuu/satysfi-matrix.git
+cd satysfi-matrix
+mkdir %USERPROFILE%\.satysfi\dist\packages\matrix
+copy matrix.satyh %USERPROFILE%\.satysfi\dist\packages\matrix\
 ```
 
 ## Uninstallation
 
-Delete `LIBROOT/dist/packages/matrix.satyh`.
+### Satyrographos
+
+Remove `satysfi-matrix` package.
+
+```sh
+opam uninstall satysfi-matrix
+```
+
+### Manually Copying
+
+Delete `LIBROOT/dist/packages/matrix/matrix.satyh`.
 
 ## Known Issues
 

--- a/Satyristes
+++ b/Satyristes
@@ -1,0 +1,23 @@
+(version "0.0.2")
+(library
+  (name "matrix")
+  (version "0.0.1")
+  (sources
+    ((package "matrix.satyh" "./matrix.satyh")))
+  (opam "satysfi-matrix.opam"))
+(libraryDoc
+  (name "matrix-doc")
+  (version "0.2")
+  (workingDirectory "example")
+  (build
+    ((satysfi "main.saty" "-o" "main.pdf")))
+  (sources
+    ((doc "example/main.saty" "example/main.saty")
+     (doc "example/main.pdf" "example/main.pdf")
+     (doc "CHANGELOG.md" "./CHANGELOG.md")
+     (doc "LICENSE" "./LICENSE")
+     (doc "README-ja.md" "./README-ja.md")
+     (doc "README.md" "./README.md")
+     (doc "doc/img/sample_matrix.png" "./doc/img/sample_matrix.png")))
+  (opam "satysfi-matrix-doc.opam")
+  (dependencies ((matrix ()))))

--- a/example/main.saty
+++ b/example/main.saty
@@ -1,5 +1,5 @@
 @require: stdjareport
-@require: matrix
+@require: matrix/matrix
 
 document (|
   title = {Examples of Matrix Library};

--- a/satysfi-matrix-doc.opam
+++ b/satysfi-matrix-doc.opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+name: "satysfi-grcnum-doc"
+version: "0.0.1"
+synopsis: "Document: Math matrix library for SATySFi"
+description: """
+Document: Matrices in SATySFi!
+
+this requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.
+"""
+maintainer: "nekketsuuu <nekketsuuu@users.noreply.github.com>"
+authors: "nekketsuuu <nekketsuuu@users.noreply.github.com>"
+license: "Unlicense"
+homepage: "https://github.com/nekketsuuu/satysfi-matrix"
+bug-reports: "https://github.com/nekketsuuu/satysfi-matrix/issues"
+dev-repo: "git+https://github.com/nekketsuuu/satysfi-matrix.git"
+depends: [
+  "satysfi" {>= "0.0.3" & < "0.0.4"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-matrix" {= "0.0.1"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "matrix-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "matrix-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+remove: [
+  ["satyrographos" "opam" "uninstall"
+   "-name" "matrix-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]

--- a/satysfi-matrix.opam
+++ b/satysfi-matrix.opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+name: "satysfi-matrix"
+version: "0.0.1"
+synopsis: "Math matrix library for SATySFi"
+description: """
+Matrices in SATySFi!
+
+this requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.
+"""
+maintainer: "nekketsuuu <nekketsuuu@users.noreply.github.com>"
+authors: "nekketsuuu <nekketsuuu@users.noreply.github.com>"
+license: "Unlicense"
+homepage: "https://github.com/nekketsuuu/satysfi-matrix"
+bug-reports: "https://github.com/nekketsuuu/satysfi-matrix/issues"
+dev-repo: "git+https://github.com/nekketsuuu/satysfi-matrix.git"
+depends: [
+  "satysfi" {>= "0.0.3" & < "0.0.4"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+]
+build: [ ]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "matrix"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+remove: [
+  ["satyrographos" "opam" "uninstall"
+   "-name" "matrix"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]


### PR DESCRIPTION
This PR makes `satysfi-matrix` installable with Satyrographos.

- Add `Satyristes` a build file.
- Add two OPAM package files `satysfi-matrix.opam` and `satysfi-matrix-doc.opam`.
- Update `README.md` and `README-ja.md`.
- Replace `@require: matrix` for `@require: matrix/matrix` in `example/main.saty`
  - This follows new Satyrographos directory hierarchy, which resembles the planned SATySFi package schema.